### PR TITLE
对样式的一些阴间（自认为）的地方进行修改

### DIFF
--- a/argon-luogu.user.styl
+++ b/argon-luogu.user.styl
@@ -121,6 +121,7 @@ if dark-mode
 	hljs_addition_bg_color = #033a16
 	hljs_deletion_color = #ffdcd7
 	hljs_deletion_bg_color = #67060c
+	line_colore = #a6a6a6
 else
 	body_bg_color = #eee
 	navbar_bg_color = #eeeeee
@@ -142,6 +143,7 @@ else
 	button_bg_color = transparent
 	selection_bg_color = #264f78
 	acrylic_bg_color = #ffffff
+	line_colore = #595959
 
 // ! 配置部分结束 ---------
 
@@ -540,7 +542,7 @@ mdeditor-patch()
 		
 		// 「展开全文」
 		.collapsed-wrapper > .expand > .expand
-			background linear-gradient(rgba(255, 255, 255, 0), rgba(grey, 0.5))
+			background none
 			border-radius 8px
 			padding-top 5em // 拉长一点
 		
@@ -560,7 +562,6 @@ mdeditor-patch()
 		.input > pre, .output > pre
 			background inlinecode_bg_color
 			border none !important
-
 	// 去除广告
 	if remove-ad
 		div[data-v-0a593618]
@@ -938,7 +939,7 @@ mdeditor-patch()
 			padding-left 1em // 作者栏和正文对齐，更整齐
 			padding-right 1em
 
-		div[data-v-75c8fc68]:nth-child(2) // 正文
+		div[data-v-5b390a88]:nth-child(2) // 正文
 			background none !important
 
 			.article-content
@@ -955,10 +956,10 @@ mdeditor-patch()
 						color button_hover_bg_color !important
 				
 				// 右侧目录
-				.toc-wrapper[data-v-318b4974]
+				.toc-wrapper
 					right -200px !important
 
-					.toc[data-v-318b4974]
+					.toc[data-v-463b40c0]
 						border-radius 6px
 						padding 1em
 						acrylic()
@@ -1054,10 +1055,40 @@ mdeditor-patch()
 				background board_color !important
 			
 			color post_text_color
-   .expand[data-v-9f81deee]
-      background #fff0
+			transition:box-shadow 0.1s linear
 	a[data-v-29ea9268-s]
-      background #ffffff
-      acrylic-bg(0.6,20px)
+      z-index 100
+      position absolute
+      top 0
+      bottom 0
+      left 0
+      right 0
+      acrylic-bg(0.6,2px)
       padding: 4pt 4pt 4pt 4pt
       border-radius 5pt
+      display: flex;
+      align-items: center;
+      justify-content: center;
+   a[data-v-29ea9268-s]:hover
+      z-index 100
+      position absolute
+      top 0
+      bottom 0
+      left 0
+      right 0
+      acrylic-bg(0.6,2px)
+      padding: 4pt 4pt 4pt 4pt
+      border-radius 5pt
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      
+   .row[data-v-83fd4045]
+      acrylic-bg(0.8,20px)
+      padding 8pt 8pt 8pt 8pt
+      margin-top 8pt !important
+      border-radius 5pt
+      transition:box-shadow 0.1s linear
+   .expand
+      height 2em
+      padding 0pt 0pt 0pt 0pt !important

--- a/argon-luogu.user.styl
+++ b/argon-luogu.user.styl
@@ -121,7 +121,6 @@ if dark-mode
 	hljs_addition_bg_color = #033a16
 	hljs_deletion_color = #ffdcd7
 	hljs_deletion_bg_color = #67060c
-	line_colore = #a6a6a6
 else
 	body_bg_color = #eee
 	navbar_bg_color = #eeeeee
@@ -143,7 +142,6 @@ else
 	button_bg_color = transparent
 	selection_bg_color = #264f78
 	acrylic_bg_color = #ffffff
-	line_colore = #595959
 
 // ! 配置部分结束 ---------
 

--- a/argon-luogu.user.styl
+++ b/argon-luogu.user.styl
@@ -14,6 +14,7 @@
 @var	checkbox nav-acrylic "侧栏亚克力效果" 1
 @var	checkbox card-acrylic "卡片亚克力效果" 1
 @var	checkbox footer-acrylic "底栏亚克力效果" 1
+@var	checkbox anymore-acrylic "其余亚克力效果" 1
 @var	checkbox remove-ad "去除洛谷广告" 0
 @var	checkbox remove-reply-container "隐藏讨论区「编辑回复」栏" 0
 ==/UserStyle== */
@@ -166,6 +167,7 @@ acrylic(arc-opacity=0.5,blur-radius=10px,no_shadow=false)
 		left 0
 		right 0
 		bottom 0
+		transform: translateZ(0);
 
 // https://stackoverflow.com/questions/44522299/css-only-acrylic-material-from-fluent-design-system
 // 直接修改背景的亚克力实现，不需要修改 z-index，不会对 border-radius 造成影响，但可能造成层叠混乱
@@ -175,6 +177,7 @@ acrylic-bg(arc-opacity=0.5,blur-radius=10px,no_shadow=false)
 	backdrop-filter blur(blur-radius) !important unless blur-radius == 0
 	box-shadow	0 10px	30px	rgba(0, 0, 0, 0.1),
 				0 1px	8px		rgba(0, 0, 0, 0.2) unless no_shadow !important
+	transform: translateZ(0);
 
 // 修改 Markdown 渲染内容样式
 markdown-patch()
@@ -395,8 +398,13 @@ mdeditor-patch()
 		border none !important
 		& > ul > li:hover
 			background button_hover_bg_color !important
+	if remove-ad
+		div[data-v-5d92dbda]
+        display none
+   .drop[data-v-64ec303c]
+		acrylic-bg()
 
-// 主站
+   // 主站
 @-moz-document regexp("^(https?://www.luogu.com(.cn)?/)(?!(article/|problem/solution/|ranking)).*")
 	/* 页面布局 */
 	// 覆盖掉洛谷主题自带的背景
@@ -560,6 +568,12 @@ mdeditor-patch()
 		.input > pre, .output > pre
 			background inlinecode_bg_color
 			border none !important
+     //提交代码
+		.drop
+        if anymore-acrylic
+            acrylic()
+        else
+            background board_color
 	// 去除广告
 	if remove-ad
 		div[data-v-0a593618]
@@ -960,7 +974,10 @@ mdeditor-patch()
 					.toc[data-v-463b40c0]
 						border-radius 6px
 						padding 1em
-						acrylic()
+						if card-acrylic
+                    acrylic()
+                else
+                    background board_color
 						top 1em
 					
 					.toc>ul>li[data-v-318b4974]:hover::before,
@@ -1053,7 +1070,6 @@ mdeditor-patch()
 				background board_color !important
 			
 			color post_text_color
-			transition:box-shadow 0.1s linear
 	a[data-v-29ea9268-s]
       z-index 100
       position absolute
@@ -1061,7 +1077,10 @@ mdeditor-patch()
       bottom 0
       left 0
       right 0
-      acrylic-bg(0.6,2px)
+      if anymore-acrylic
+          acrylic-bg(0.6,2px)
+      else
+          background board_color !important
       padding: 4pt 4pt 4pt 4pt
       border-radius 5pt
       display: flex;
@@ -1074,19 +1093,29 @@ mdeditor-patch()
       bottom 0
       left 0
       right 0
-      acrylic-bg(0.6,2px)
+      if anymore-acrylic
+          acrylic-bg(0.6,2px)
+      else
+          background board_color !important
       padding: 4pt 4pt 4pt 4pt
       border-radius 5pt
       display: flex;
       align-items: center;
       justify-content: center;
-      
-   .row[data-v-83fd4045]
-      acrylic-bg(0.8,20px)
+   a[data-v-9f81deee]
+      color text_color !important
+	div[data-v-83fd4045] .list-wrap .row-wrap .row[data-v-83fd4045]
+      if anymore-acrylic
+          acrylic-bg(0.6,2px)
+      else
+          background board_color !important
       padding 8pt 8pt 8pt 8pt
       margin-top 8pt !important
       border-radius 5pt
-      transition:box-shadow 0.1s linear
-   .expand
+      markdown-patch()
+   .expand[data-v-9f81deee]
+      background none
       height 2em
       padding 0pt 0pt 0pt 0pt !important
+   .lside
+     overflow none


### PR DESCRIPTION
- 对毛玻璃效果进行性能优化
- 使广告删除功能生效
- 提交评测功能的“上传文件”按钮对深色模式适配
- 让毛玻璃选项生效
- 题解卡片化，之前的样式每一篇题解之间分割不明显
- 代码块适配深色模式
- 一些小细节（比如再次修改展开全文按钮让它更阳间）